### PR TITLE
CCM-18946: Sonar PR Decoration Fixes

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -3,13 +3,17 @@ name: "1. CI/CD pull request"
 # The total recommended execution time for the "CI/CD Pull Request" workflow is around 20 minutes.
 
 on:
-  push:
-    branches:
-      - "**"
-  pull_request:
-    types: [opened, reopened]
+  push: ## Only trigger on pushes to main branch to prevent unnecessary runs on feature branches, as the pull_request trigger will handle PR events.
     branches:
       - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   metadata:

--- a/scripts/reports/perform-static-analysis.sh
+++ b/scripts/reports/perform-static-analysis.sh
@@ -37,12 +37,15 @@ function main() {
 
 function run-sonar-scanner-natively() {
 
+  local -a context_args
+  context_args=($(build-sonar-context-args))
+
   sonar-scanner \
     -Dproject.settings="$PWD/scripts/config/sonar-scanner.properties" \
-    -Dsonar.branch.name="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}" \
     -Dsonar.organization="$SONAR_ORGANISATION_KEY" \
     -Dsonar.projectKey="$SONAR_PROJECT_KEY" \
-    -Dsonar.token="$SONAR_TOKEN"
+    -Dsonar.token="$SONAR_TOKEN" \
+    "${context_args[@]}"
 
   return 0
 }
@@ -52,18 +55,36 @@ function run-sonar-scanner-in-docker() {
   # shellcheck disable=SC1091
   source ./scripts/docker/docker.lib.sh
 
+  local -a context_args
+  context_args=($(build-sonar-context-args))
+
   # shellcheck disable=SC2155
   local image=$(name=sonarsource/sonar-scanner-cli docker-get-image-version-and-pull)
   docker run --rm --platform linux/amd64 \
     --volume "$PWD":/usr/src \
     "$image" \
       -Dproject.settings=/usr/src/scripts/config/sonar-scanner.properties \
-      -Dsonar.branch.name="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}" \
       -Dsonar.organization="$SONAR_ORGANISATION_KEY" \
       -Dsonar.projectKey="$SONAR_PROJECT_KEY" \
-      -Dsonar.token="$SONAR_TOKEN"
+      -Dsonar.token="$SONAR_TOKEN" \
+      "${context_args[@]}"
 
   return 0
+}
+
+# ==============================================================================
+
+function build-sonar-context-args() {
+
+  if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+    local pr_number
+    pr_number=$(echo "${GITHUB_REF:-}" | grep -oP 'refs/pull/\K[0-9]+')
+    echo "-Dsonar.pullrequest.key=${pr_number}"
+    echo "-Dsonar.pullrequest.branch=${GITHUB_HEAD_REF:-${BRANCH_NAME}}"
+    echo "-Dsonar.pullrequest.base=${GITHUB_BASE_REF:-main}"
+  else
+    echo "-Dsonar.branch.name=${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+  fi
 }
 
 # ==============================================================================


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Problem

SonarCloud PR decoration (quality gate comment on PRs) was not appearing reliably on pushes to open PRs.

Two root causes were identified:

1. `scripts/reports/perform-static-analysis.sh` always passed `-Dsonar.branch.name`, forcing SonarCloud into **branch analysis mode**.  
   PR decoration requires **PR analysis mode** with:
   - `sonar.pullrequest.key`
   - `sonar.pullrequest.branch`
   - `sonar.pullrequest.base`

2. The PR workflow did not previously run with PR context on every PR update.  
   Without `pull_request: synchronize`, pushes to an open PR could miss the required PR event context for Sonar PR analysis.

---

## Fix

### 1) Sonar scanner context switching in static analysis script
Updated `scripts/reports/perform-static-analysis.sh` to build Sonar arguments dynamically:

- For `GITHUB_EVENT_NAME=pull_request`:
  - `-Dsonar.pullrequest.key=...`
  - `-Dsonar.pullrequest.branch=...`
  - `-Dsonar.pullrequest.base=...`
- Otherwise:
  - `-Dsonar.branch.name=...`

This enables proper SonarCloud PR decoration for PR-triggered runs while preserving branch analysis for non-PR runs.

### 2) PR workflow now triggers on PR updates (`synchronize`)
Updated `.github/workflows/cicd-1-pull-request.yaml`:

- `pull_request.types` now includes:
  - `opened`
  - `reopened`
  - `synchronize`

This ensures each push to an open PR runs in PR event context, allowing the script above to select PR analysis mode.

### 3) Added concurrency guard to avoid duplicate CI spend
Added workflow concurrency for same ref:

- Group: `${{ github.workflow }}-${{ github.head_ref || github.ref_name }}`
- `cancel-in-progress: true`

### 4) Added `push` trigger for `main`
Updated `.github/workflows/cicd-1-pull-request.yaml` to also run on:

- `push.branches: [main]`

This ensures the pipeline runs after PR merge to `main` for post-merge validation/publish flow.

---

## Resulting behavior

- **On PR open/reopen/update**: workflow runs with `pull_request` context, Sonar uses PR analysis mode, decoration can be posted to PR.
- **On merge to main**: workflow runs on `push` to `main`.
- **Duplicate run protection**: concurrency cancels superseded runs for the same branch/workflow key.
- **PR Workflow no longer runs on commits prior to PR creation**: may be contentious but more in line with the workflow's intention.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

## DT3-Specific Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] If I have added a new resource (SQS, Lambda, Gateway, DDB table, etc), I have created the appropriate alarms

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
